### PR TITLE
Maintained backward compatibility with existing /hello endpoint

### DIFF
--- a/controllers/hello_controller.go
+++ b/controllers/hello_controller.go
@@ -20,12 +20,30 @@ func NewHelloController(helloService *services.HelloService) *HelloController {
 }
 
 // RegisterRoutes registers the routes for HelloController
-func (c *HelloController) RegisterRoutes(router *gin.Engine) {
+func (c *HelloController) RegisterRoutes(router *gin.RouterGroup) {
 	router.GET("/hello", c.getHello)
+	router.GET("/hello/:name", c.getPersonalizedHello)
 }
 
 // getHello handles GET /hello
 func (c *HelloController) getHello(ctx *gin.Context) {
 	message := c.helloService.GetHelloMessage()
 	ctx.JSON(http.StatusOK, gin.H{"message": message})
+}
+
+// getPersonalizedHello handles GET /hello/:name
+func (c *HelloController) getPersonalizedHello(ctx *gin.Context) {
+	name := ctx.Param("name")
+	
+	message, err := c.helloService.GetPersonalizedGreeting(name)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+	
+	ctx.JSON(http.StatusOK, gin.H{
+		"greeting": message,
+	})
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"code-review-bot-test-repo/controllers"
+	"code-review-bot-test-repo/services"
 	"github.com/gin-gonic/gin"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/rs/zerolog"
@@ -77,6 +78,7 @@ func getEnv(key, defaultValue string) string {
 func setupRouter(db *sql.DB) *gin.Engine {
 	// Initialize controllers
 	userController := controllers.NewUserController(db)
+	helloController := controllers.NewHelloController(services.NewHelloService())
 
 	// Create Gin router with recovery middleware
 	r := gin.New()
@@ -90,6 +92,9 @@ func setupRouter(db *sql.DB) *gin.Engine {
 	{
 		// User routes
 		userController.RegisterRoutes(api)
+
+		// Hello routes
+		helloController.RegisterRoutes(api)
 
 		// Health check endpoint
 		api.GET("/health", func(c *gin.Context) {

--- a/services/hello_service.go
+++ b/services/hello_service.go
@@ -1,5 +1,10 @@
 package services
 
+import (
+	"errors"
+	"strings"
+)
+
 // HelloService handles the business logic for hello operations
 type HelloService struct{}
 
@@ -11,4 +16,15 @@ func NewHelloService() *HelloService {
 // GetHelloMessage returns a hello world message
 func (s *HelloService) GetHelloMessage() string {
     return "Hello, World!"
+}
+
+// GetPersonalizedGreeting returns a personalized greeting message
+func (s *HelloService) GetPersonalizedGreeting(name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", errors.New("name cannot be empty")
+	}
+	if len(name) > 50 {
+		return "", errors.New("name is too long (max 50 characters)")
+	}
+	return "Hello, " + name + "!", nil
 }


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Add Personalized Hello Endpoint with Backward Compatibility**

This PR introduces a new personalized greeting endpoint `/hello/:name` while maintaining backward compatibility for the original `/hello` endpoint. The implementation updates the controller and service layers to handle both routes, including input validation and error handling for the personalized greeting.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `HelloController`.`RegisterRoutes` to accept a gin.`RouterGroup` and register both /hello and /hello/:name endpoints.
• Added `getPersonalizedHello` method to `HelloController` for handling personalized greetings.
• Extended `HelloService` with `GetPersonalizedGreeting` (validates name: non-empty, max 50 chars) returns a greeting or error.
• main.go updated to initialize and register the new `HelloController` and its routes.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• controllers/`hello_controller`.go
• services/`hello_service`.go
• main.go

</details>

---
*This summary was automatically generated by @propel-code-bot*